### PR TITLE
Mention all of the paths that have to be set in the relevant error message

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -30,7 +30,7 @@ func Launch(unlockManager *unlocks.Manager) (*Session, error) {
 	}
 
 	if settings.Get().SmExePath == "" || settings.Get().SmSaveDir == "" || settings.Get().SmSongsDir == "" {
-		return nil, fmt.Errorf("Please set the path to your StepMania executable in the settings!")
+		return nil, fmt.Errorf("Please set the paths to your StepMania executable and the Save and Songs directories in the settings!")
 	}
 
 	err := sess.startIpc()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -30,7 +30,7 @@ func Launch(unlockManager *unlocks.Manager) (*Session, error) {
 	}
 
 	if settings.Get().SmExePath == "" || settings.Get().SmSaveDir == "" || settings.Get().SmSongsDir == "" {
-		return nil, fmt.Errorf("Please set the paths to your StepMania executable and the Save and Songs directories in the settings!")
+		return nil, fmt.Errorf("Please set paths to your StepMania executable, the Save directory, and the Songs directory in the settings!")
 	}
 
 	err := sess.startIpc()


### PR DESCRIPTION
We got a few people in Discord that were wondering why they were getting this error message when they _had_ set the path to the StepMania executable:
![image](https://user-images.githubusercontent.com/706916/166168019-0ce9a05c-feb9-46d9-acf0-5e1c18b1a5d6.png)

So I changed it to one that covers all of the cases where it's shown:
![image](https://user-images.githubusercontent.com/706916/166168005-5760e25a-3163-4981-8f53-91e7106d0c77.png)
