### PR TITLE
Expose GrooveStats API endpoint URL

### DIFF
--- a/internal/gui/settings.go
+++ b/internal/gui/settings.go
@@ -230,6 +230,15 @@ func (app *App) getSettingsForm(data *settings.Settings) fyne.CanvasObject {
 	})
 	autoLaunchCheck.SetChecked(data.AutoLaunch)
 
+	gsUrlEntry := widget.NewEntry()
+	gsUrlEntry.Text = data.GrooveStatsUrl
+	gsUrlEntry.OnChanged = func(url string) {
+		data.GrooveStatsUrl = url
+	}
+
+	gsUrlFormItem := widget.NewFormItem("GrooveStats API endpoint", gsUrlEntry)
+	gsUrlFormItem.HintText = "Do not modify unless you know what you are doing!"
+
 	form := widget.NewForm(
 		smExeButtonFormItem,
 		smSaveDirFormItem,
@@ -238,6 +247,7 @@ func (app *App) getSettingsForm(data *settings.Settings) fyne.CanvasObject {
 		autoDownloadFormItem,
 		widget.NewFormItem("Separate Unlocks by User", userUnlocksCheck),
 		widget.NewFormItem("Launch StepMania at Startup", autoLaunchCheck),
+		gsUrlFormItem,
 	)
 
 	return form
@@ -292,7 +302,7 @@ func (app *App) showSettingsDialog() {
 			app.unlockWidget.Refresh()
 		}
 	}, app.mainWin)
-	settingsDialog.Resize(fyne.NewSize(700, 500))
+	settingsDialog.Resize(fyne.NewSize(700, 550))
 	settingsDialog.Show()
 }
 
@@ -364,12 +374,6 @@ func (app *App) showDebugSettingsDialog() {
 		fakeGsRpgCheck.Disable()
 		fakeGsItlCheck.Disable()
 		fakeGsNetDelayEntry.Disable()
-	}
-
-	gsUrlEntry := widget.NewEntry()
-	gsUrlEntry.Text = data.GrooveStatsUrl
-	gsUrlEntry.OnChanged = func(url string) {
-		data.GrooveStatsUrl = url
 	}
 
 	items := []*widget.FormItem{

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -60,6 +60,7 @@ type Settings struct {
 	AutoDownloadMode AutoDownloadMode
 	UserUnlocks      bool
 	AutoLaunch       bool
+	GrooveStatsUrl   string
 
 	// debug settings, not stored in the json
 	Debug                  bool   `json:"-"`


### PR DESCRIPTION
The URL would now be stored in config file and visible in normal settings dialog.
This will allow people to change it to point at alternative stats aggregators with compatible API.